### PR TITLE
Implement validating only the response

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@ composer require --dev gertjuhh/symfony-openapi-validator
 - Call `self::assertOpenApiSchema(<schema>, <client>);`
     - `schema`: path to corresponding OpenAPI yaml schema
     - `client`: the client used to make the request
+- Or optionally use the `self::assertResponseAgainstOpenApiSchema(<schema>, <client>);` to only validate the response
+    - The `operationAddress` can be passed as a third argument for this function but by default it will retrieve the 
+      operation from the `client`.
 
 ## Example
 

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -48,12 +48,12 @@ paths:
           content:
             application/json:
               schema:
-                  type: object
-                  required:
+                type: object
+                required:
                   - message
-                  properties:
-                    message:
-                      type: string
+                properties:
+                  message:
+                    type: string
 
 components:
   schemas:

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -25,6 +25,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/NestedProperty'
 
+  /input-validation:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type:
+                object
+              required:
+                - email
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: john.doe@example.com
+      responses:
+        200:
+          description: Ok
+        422:
+          description: Input is invalid
+          content:
+            application/json:
+              schema:
+                  type: object
+                  required:
+                  - message
+                  properties:
+                    message:
+                      type: string
+
 components:
   schemas:
     HelloWorld:


### PR DESCRIPTION
This PR adds support for validating only the response, without checking the request body. This can be useful when you want to purposely test the result of an error.