### PR TITLE
Add output for inner exceptions thrown with NotEnoughValidSchemas

### DIFF
--- a/src/OpenApiValidator.php
+++ b/src/OpenApiValidator.php
@@ -62,8 +62,13 @@ trait OpenApiValidator
 
     private static function extractPathFromException(\Throwable $exception): string | null
     {
-        if ($exception instanceof SchemaMismatch && $breadcrumb = $exception->dataBreadCrumb()) {
-            return \implode('.', $breadcrumb->buildChain());
+        if ($exception instanceof SchemaMismatch
+            && ($breadcrumb = $exception->dataBreadCrumb())
+            // league/openapi-psr7-validator can return an array with a single null value
+            // when the breadcrumb's first compoundIndex is null; filter this out here
+            && !empty($chain = array_filter($breadcrumb->buildChain()))
+        ) {
+            return \implode('.', $chain);
         }
 
         return null;
@@ -118,7 +123,7 @@ trait OpenApiValidator
             \sprintf(
                 'OpenAPI %s error%s:%s%s',
                 $scope,
-                !empty($at)
+                $at !== null
                     ? sprintf(' at %s', $at)
                     : '',
                 "\n",

--- a/src/OpenApiValidator.php
+++ b/src/OpenApiValidator.php
@@ -60,7 +60,7 @@ trait OpenApiValidator
         }
     }
 
-    private static function extractPathFromException(\Throwable $exception): ?string
+    private static function extractPathFromException(\Throwable $exception): string | null
     {
         if ($exception instanceof SchemaMismatch && $breadcrumb = $exception->dataBreadCrumb()) {
             return \implode('.', $breadcrumb->buildChain());

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -15,6 +15,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/HelloWorld'
 
+  /match-oneof:
+    get:
+      responses:
+        200:
+          description: Hello world request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/HelloWorld'
+                  - $ref: '#/components/schemas/NestedProperty'
+
   /nested-property:
     get:
       responses:

--- a/tests/unit/OpenApiValidatorTest.php
+++ b/tests/unit/OpenApiValidatorTest.php
@@ -94,7 +94,7 @@ final class OpenApiValidatorTest extends TestCase
             'HTTP_X_REQUESTED_WITH',
             'XMLHttpRequest',
         ]);
-        $response = new JsonResponse(['foo' => 'bar'], headers: ['content-type' => 'application/json']);
+        $response = new JsonResponse(['nested' => new \stdClass()], headers: ['content-type' => 'application/json']);
 
         $browser = $this->createMock(KernelBrowser::class);
         $browser->expects(self::once())
@@ -113,7 +113,7 @@ final class OpenApiValidatorTest extends TestCase
                         'Body does not match schema for content-type "application/json" for Response [get /match-oneof 200]',
                         'Keyword validation failed: Data must match exactly one schema, but matched none',
                         '==> Schema 1: Keyword validation failed: Required property \'hello\' must be present in the object (at hello)',
-                        '==> Schema 2: Keyword validation failed: Required property \'nested\' must be present in the object (at nested)',
+                        '==> Schema 2: Keyword validation failed: Required property \'property\' must be present in the object (at nested.property)',
                     ],
                 ),
             )


### PR DESCRIPTION
When using a keyword like `oneOf` which can throw a NotEnoughValidSchemas exception, the validator will now output details on all schema matches:

```
OpenAPI response error:
Body does not match schema for content-type "application/json" for Response [get /match-oneof 200]
Keyword validation failed: Data must match exactly one schema, but matched none
==> Schema 1: Keyword validation failed: Required property 'hello' must be present in the object (at hello)
==> Schema 2: Keyword validation failed: Required property 'nested' must be present in the object (at nested)
```