### PR TITLE
Create a static cache class to share cache pools between tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,26 @@ composer require --dev gertjuhh/symfony-openapi-validator
     - The `operationAddress` can be passed as a third argument for this function but by default it will retrieve the 
       operation from the `client`.
 
+### Setting up a cache
+
+The [underlying library can use a PSR-6 cache](https://github.com/thephpleague/openapi-psr7-validator#caching-layer--psr-6-support).
+This provides a significant speedup when running multiple tests against a single schema, since it can be parsed once and 
+reused.
+
+In order to activate this cache, you can pass a PSR-6 cache instance to the static property
+`\Gertjuhh\SymfonyOpenapiValidator\StaticOpenApiValidatorCache::$validatorCache`. For example:
+
+```php
+<?php
+
+use Gertjuhh\SymfonyOpenapiValidator\StaticOpenApiValidatorCache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+StaticOpenApiValidatorCache::$validatorCache = new ArrayAdapter();
+```
+
+This snippet can be embedded in a bootstrap script for PHPUnit.
+
 ## Example
 
 ```PHP

--- a/src/StaticOpenApiValidatorCache.php
+++ b/src/StaticOpenApiValidatorCache.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gertjuhh\SymfonyOpenapiValidator;
+
+use League\OpenAPIValidation\PSR7\ValidatorBuilder;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+
+final class StaticOpenApiValidatorCache
+{
+    private static PsrHttpFactory | null $psrHttpFactory = null;
+
+    /** @var array<string, ValidatorBuilder> */
+    private static array $validatorBuilder = [];
+
+    /**
+     * Install a cache pool for the OpenAPI Validator
+     *
+     * @see https://github.com/thephpleague/openapi-psr7-validator#caching-layer--psr-6-support
+     */
+    public static CacheItemPoolInterface|null $validatorCache = null;
+
+    public static function getPsrHttpFactory(): PsrHttpFactory
+    {
+        if (null === self::$psrHttpFactory) {
+            $psr17Factory = new Psr17Factory();
+            self::$psrHttpFactory = new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+        }
+
+        return self::$psrHttpFactory;
+    }
+
+    public static function getValidatorBuilder(string $schema): ValidatorBuilder
+    {
+        if (!\array_key_exists($schema, self::$validatorBuilder)) {
+            self::$validatorBuilder[$schema] = (new ValidatorBuilder())
+                ->fromYamlFile($schema);
+
+            if (self::$validatorCache !== null) {
+                self::$validatorBuilder[$schema]->setCache(self::$validatorCache);
+            }
+        }
+
+        return self::$validatorBuilder[$schema];
+    }
+}


### PR DESCRIPTION
This fixes several performance issues:
- OpenAPI YAML definitions are reloaded on every test class since static properties are not shared in traits,
- Allows for the use of a cache adapter according to https://github.com/thephpleague/openapi-psr7-validator#caching-layer--psr-6-support, greatly speeding up tests