### PR TITLE
Set storeSerialized to false in the readme cache example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,11 @@ In order to activate this cache, you can pass a PSR-6 cache instance to the stat
 use Gertjuhh\SymfonyOpenapiValidator\StaticOpenApiValidatorCache;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-StaticOpenApiValidatorCache::$validatorCache = new ArrayAdapter();
+StaticOpenApiValidatorCache::$validatorCache = new ArrayAdapter(storeSerialized: false);
 ```
+
+Setting `storeSerialized` to false on the ArrayAdapter instance is recommended as it lowers memory usage by storing the actual objects; 
+otherwise, Symfony will store a serialized representation of the OpenAPI schema and deserialize it on every test run. 
 
 This snippet can be embedded in a bootstrap script for PHPUnit.
 


### PR DESCRIPTION
`storeSerialized` caused excessive memory usage in our test suites. Disabling it stores the actual objects in the ArrayAdapter cache, which negates the need for Symfony to serialize & deserialize the OpenAPI schema for every test.